### PR TITLE
Adiciona pequenas correções

### DIFF
--- a/dsm/core/document_files.py
+++ b/dsm/core/document_files.py
@@ -323,7 +323,7 @@ def register_assets(files_storage, files_storage_folder,
                 doc_package.zip_file_path,
             )
             asset_in_xml.xlink_href = uri_and_name["uri"]
-        except FilesStorageRegisterError as e:
+        except exceptions.FilesStorageRegisterError as e:
             errors.append({"error": str(e)})
     return errors
 

--- a/dsm/extdeps/db.py
+++ b/dsm/extdeps/db.py
@@ -194,7 +194,7 @@ def save_data(data):
         # exceptions.DBSaveDataError(e)
 
 
-def create_remote_and_local_file(local, remote, annotation=None):
+def create_remote_and_local_file(remote, local, annotation=None):
     try:
         file = {}
         if local:
@@ -207,7 +207,7 @@ def create_remote_and_local_file(local, remote, annotation=None):
     except Exception as e:
         raise exceptions.RemoteAndLocalFileError(
             "Unable to create RemoteAndLocalFile(%s, %s): %s" %
-            (local, remote, e)
+            (remote, local, e)
         )
 
 

--- a/dsm/ingress.py
+++ b/dsm/ingress.py
@@ -39,7 +39,7 @@ def download_package(v3):
     return _docs_manager.get_zip_document_package(v3)
 
 
-def upload_package(source, pid_v2_items=None, old_filenames=None,
+def upload_package(source, pid_v2_items={}, old_filenames={},
                    issue_id=None):
     """
     Receive the package which is a folder or zip file


### PR DESCRIPTION
#### O que esse PR faz?
- Corrige nome de módulo faltante ao chamar exceção FileStorageRegisterException
- Corrige ordem de atributos uri e name ao registrar pacote (estavam invertidos fazendo com que `uri` estivesse com o nome do pacote e `name` estivesse com a uri remota do pacote)
- Altera de `None` para `{}` o valor padrão dos parâmetros `pid_v2_items` e `old_filenames` na assinatura do método `upload_package(source, pid_v2_items={}, old_filenames={},...)`

#### Onde a revisão poderia começar?
Por commits.

#### Como este poderia ser testado manualmente?
N/A

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A