### PR TITLE
[Migration] Completa campos importantes de journal e issue

### DIFF
--- a/dsm/extdeps/isis_migration/migration_manager.py
+++ b/dsm/extdeps/isis_migration/migration_manager.py
@@ -610,7 +610,7 @@ def _update_issue_with_isis_data(issue, f_issue):
 
     # nao presente na base isis
     # TODO: verificar o uso no site
-    # issue.type = f_issue.type
+    issue.type = _get_issue_type(f_issue)
 
     # supplement
     issue.suppl_text = f_issue.suppl
@@ -655,6 +655,23 @@ def _update_issue_with_isis_data(issue, f_issue):
         issue.number,
         issue.suppl_text,
     )
+
+
+def _get_issue_type(f_issue):
+    """
+    https://github.com/scieloorg/opac-airflow/blob/1064b818fda91f73414a6393d364663bdefa9665/airflow/dags/sync_kernel_to_website.py#L511
+    https://github.com/scieloorg/opac_proc/blob/3c6bd66040de596e1af86a99cca6d205bfb79a68/opac_proc/transformers/tr_issues.py#L76
+    'ahead', 'regular', 'special', 'supplement', 'volume_issue'
+    """
+    if f_issue.suppl:
+        return "supplement"
+    if f_issue.number:
+        if f_issue.number == "ahead":
+            return "ahead"
+        if "spe" in f_issue.number:
+            return "special"
+        return "regular"
+    return "volume_issue"
 
 
 def _update_journal_with_isis_data(journal, f_journal):


### PR DESCRIPTION
#### O que esse PR faz?
Completa campos importantes de `journal.current_status` com `current` e `issue.type` com um dos valores: `'ahead', 'regular', 'special', 'supplement', 'volume_issue'`. Sem estes campos journal e issue não ficam disponíveis.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando as migrações e conferindo no site se o periódico e os fascículos ficaram disponíveis.

```console
python dsm/migration.py migrate_title tests/fixtures/title.id
python dsm/migration.py migrate_issue tests/fixtures/issue.id
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
- https://github.com/scieloorg/opac-airflow/blob/1064b818fda91f73414a6393d364663bdefa9665/airflow/dags/sync_kernel_to_website.py#L511
  - https://github.com/scieloorg/opac_proc/blob/3c6bd66040de596e1af86a99cca6d205bfb79a68/opac_proc/transformers/tr_issues.py#L76
    
