### PR TITLE
Corrige situação em que tenta-se acessar método zfill (método de str) é variável int

### DIFF
--- a/dsm/core/sps_package.py
+++ b/dsm/core/sps_package.py
@@ -613,7 +613,7 @@ class Identity:
         fpage = self.fpage
         if self.fpage_seq:
             fpage += self.fpage_seq
-        last_item = (fpage or self.elocation_id or self.order or doi).zfill(5)
+        last_item = str(fpage or self.elocation_id or self.order or doi).zfill(5)
 
         data = (
             self.issn,


### PR DESCRIPTION
#### O que esse PR faz?
Corrige um pequeno bug que impede o pacote de ser montado.

#### Onde a revisão poderia começar?
Por commit.

#### Como este poderia ser testado manualmente?
1. Tente obter o pacote SVmstJZMGRWVjrkGTvqYskJ (por meio do método `get_package_uri_by_pid`)
2. Aplique a correção
3. Tente, novamente, obter o pacote SVmstJZMGRWVjrkGTvqYskJ (e verifique o sucesso)

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A