### PR TITLE
Implementa FriendlyISISDocument.abstract e FriendlyISISDocument.abstracts

### DIFF
--- a/dsm/extdeps/isis_migration/friendly_isis.py
+++ b/dsm/extdeps/isis_migration/friendly_isis.py
@@ -431,13 +431,14 @@ class FriendlyISISDocument:
 
     @property
     def abstract(self):
-        # TODO
-        return None
+        return self.abstracts.get(self.language)
 
     @property
     def abstracts(self):
-        # TODO
-        return {}
+        _abstracts = {}
+        for abstract in self._get_article_meta_items_("v083", formatted=True):
+            _abstracts[abstract.get("l")] = abstract.get("a")
+        return _abstracts
 
 
 def contrib_xref(xrefs):


### PR DESCRIPTION
#### O que esse PR faz?
Implementa FriendlyISISDocument.abstract e FriendlyISISDocument.abstracts

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
```console
python dsm/migration.py register_documents
```
Verificar o preenchimento de abstract, abstracts e abstract_languages na coleção `article` com os dados de `isis_doc`

#### Algum cenário de contexto que queira dar?
apesar de os campos estarem preenchidos o abstract não será apresentado no site, pois ele é apresentado a partir do conteúdo do XML. Mas pelo menos o links para os abstracts serão apresentados o sumário.

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
