### PR TITLE
Melhora forma de identificar se arquivo pertence a pacote

### DIFF
--- a/dsm/utils/packages.py
+++ b/dsm/utils/packages.py
@@ -127,9 +127,7 @@ def match_file_by_prefix(prefix, file_path):
         True - file belongs to the package
     """
     basename = os.path.basename(file_path)
-    if basename.startswith(prefix + "-"):
-        return True
-    if basename.startswith(prefix + "."):
+    if prefix in basename:
         return True
     return False
 


### PR DESCRIPTION
#### O que esse PR faz?
Melhora a forma de identificar se um arquivo (file_path) pertence a um pacote. A forma anterior considerava que no nome do arquivo deveria haver um termo, no começo do nome. No entanto, é mais amplo verificar se o prefixo ocorre no nome do arquivo (não necessariamente no início).

É uma abordagem que pode evitar a perda de dados.
Em experimentos prévios, verificou-se que arquivos PDFs estavam deixando de serem registrados nas bases MongoDB. Com esta alteração, o problema deixa de ocorrer.

#### Onde a revisão poderia começar?
Por commit

#### Como este poderia ser testado manualmente?
Pode-se testar como o método `match_file_by_prefix` se comporta ao receber como parâmetro diferentes valores para `prefix` e  `file_path`.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A