### PR TITLE
Remove o levantamento de exceção se o campo v014 está ausente

### DIFF
--- a/dsm/extdeps/isis_migration/friendly_isis.py
+++ b/dsm/extdeps/isis_migration/friendly_isis.py
@@ -68,8 +68,6 @@ class FriendlyISISDocument:
         self._id = _id
         self._records = records
         self._pages = self._get_article_meta_item_("v014")
-        if self._pages is None:
-            raise ValueError("missing v014: %s" % str(records[1]))
         self._set_file_name()
         self._paragraphs = FriendlyISISParagraphs(_id, self._records)
 
@@ -423,19 +421,19 @@ class FriendlyISISDocument:
 
     @property
     def elocation_id(self):
-        return self._pages.get("e")
+        return self._pages and self._pages.get("e")
 
     @property
     def fpage(self):
-        return self._pages.get("f")
+        return self._pages and self._pages.get("f")
 
     @property
     def fpage_seq(self):
-        return self._pages.get("s")
+        return self._pages and self._pages.get("s")
 
     @property
     def lpage(self):
-        return self._pages.get("l")
+        return self._pages and self._pages.get("l")
 
     @property
     def body(self):


### PR DESCRIPTION
#### O que esse PR faz?
Remove o levantamento de exceção se o campo v014 está ausente

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Tentar carregar um `artigo.id` em que o registro h não contenha o campo v14 e então não deve ocorrer exceção.
Comando:
```console
python dsm/migration.py register_artigo_id tests/fixtures/artigo.id
```
supondo que algum registro h de tests/fixtures/artigo.id não tenha o campo v014.

#### Algum cenário de contexto que queira dar?
de fato é possível haver ausência de v014 em caso de aop. O v014 é preenchido com páginas físicas ou elocation.

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

