### PR TITLE
Considerar que documento pode não ter seção de sumário

### DIFF
--- a/dsm/core/document.py
+++ b/dsm/core/document.py
@@ -448,6 +448,9 @@ def set_translated_sections(article, langs_and_sections):
     article: opac_schema.v1.models.Article
     langs_and_sections: dict
     """
+    if not langs_and_sections:
+        # documento não tem seção de sumário
+        return
     sections = []
     for lang, section in langs_and_sections.items():
         sections.append(


### PR DESCRIPTION
#### O que esse PR faz?
Considerar que documento pode não ter seção de sumário

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
Executar a migração de documentos sem seção (ex. México S0187-62362012000200001)

```console
python dsm/migration.py register_artigo_id <artigo.id>
python dsm/migration.py register_documents
```
Considerando que `<artigo.id>` tenha registro de documentos sem seção, ou seja, valor `nd`.
O erro ocorreria ao executar o segundo comando.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

