### PR TITLE
Renomeia nome inválido de campo (de _am para article_meta) em sps_package

### DIFF
--- a/dsm/core/sps_package.py
+++ b/dsm/core/sps_package.py
@@ -624,7 +624,7 @@ class Identity:
             'pub-date[@date-type="pub"]',
             "pub-date",
         )
-        return get_year_month_day(_match_pubdate(self._am, xpaths))
+        return get_year_month_day(_match_pubdate(self.article_meta, xpaths))
 
     @property
     def documents_bundle_pubdate(self):
@@ -634,7 +634,7 @@ class Identity:
             'pub-date[@date-type="collection"]',
             "pub-date",
         )
-        return get_year_month_day(_match_pubdate(self._am, xpaths))
+        return get_year_month_day(_match_pubdate(self.article_meta, xpaths))
 
     @property
     def year(self):


### PR DESCRIPTION
#### O que esse PR faz?
Renomeia o campo `_am` para `article_meta` no módulo sps_package. Este campo já havia sido renomeado em PRs anteriores, mas faltaram duas ocorrências.

#### Onde a revisão poderia começar?
N/A

#### Como este poderia ser testado manualmente?
N/A

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A