### PR TITLE
[migration] Renomeia e refatora a função que migra os dados de bases que ficam em `bases-work/acron/acron`

### DIFF
--- a/dsm/configuration.py
+++ b/dsm/configuration.py
@@ -130,7 +130,7 @@ def check_migration_sources():
     for path, name in zip(paths, names):
         if not path:
             raise ValueError(f"Missing configuration: {name}")
-        if not os.path.isdir(HTDOCS_IMG_REVISTAS_PATH):
+        if not os.path.isdir(path):
             raise ValueError(f"{name} must be a directory")
 
 


### PR DESCRIPTION
#### O que esse PR faz?
Renomeia e refatora a função que migra os dados de bases que ficam em `bases-work/acron/acron`

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Estabelecer as variáveis de ambiente etc

```console
python dsm/migration.py migrate_acron rsp
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
