### PR TITLE
Cria funcionalidade para coletar todos os pids e as datas de atualização do ISIS 

### DIFF
--- a/dsm/configuration.py
+++ b/dsm/configuration.py
@@ -31,7 +31,7 @@ BASES_XML_PATH = os.environ.get("BASES_XML_PATH")
 BASES_PDF_PATH = os.environ.get("BASES_PDF_PATH")
 BASES_TRANSLATION_PATH = os.environ.get("BASES_TRANSLATION_PATH")
 HTDOCS_IMG_REVISTAS_PATH = os.environ.get("HTDOCS_IMG_REVISTAS_PATH")
-BASES_PATH = os.path.dirname(BASES_PDF_PATH)
+BASES_PATH = os.environ.get("BASES_PATH")
 
 
 def get_http_client():

--- a/dsm/configuration.py
+++ b/dsm/configuration.py
@@ -322,7 +322,7 @@ def get_bases_acron(acron):
     return os.path.join(BASES_WORK_PATH, acron, acron)
 
 
-def get_bases_artigo_path(acron):
+def get_bases_artigo_path():
     return os.path.join(BASES_PATH, "artigo", "artigo")
 
 

--- a/dsm/configuration.py
+++ b/dsm/configuration.py
@@ -31,6 +31,7 @@ BASES_XML_PATH = os.environ.get("BASES_XML_PATH")
 BASES_PDF_PATH = os.environ.get("BASES_PDF_PATH")
 BASES_TRANSLATION_PATH = os.environ.get("BASES_TRANSLATION_PATH")
 HTDOCS_IMG_REVISTAS_PATH = os.environ.get("HTDOCS_IMG_REVISTAS_PATH")
+BASES_PATH = os.path.dirname(BASES_PDF_PATH)
 
 
 def get_http_client():
@@ -319,6 +320,10 @@ def get_files_storage_folder_for_received_packages(name, date_now_as_folder_name
 
 def get_bases_acron(acron):
     return os.path.join(BASES_WORK_PATH, acron, acron)
+
+
+def get_bases_artigo_path(acron):
+    return os.path.join(BASES_PATH, "artigo", "artigo")
 
 
 def get_htdocs_path():

--- a/dsm/extdeps/isis_migration/migration_manager.py
+++ b/dsm/extdeps/isis_migration/migration_manager.py
@@ -1362,5 +1362,5 @@ def get_document_pids_to_migrate(from_date=None, to_date=None):
         """
         for row in fp:
             # 1|OAITS=20210917=2675-54752021000300700
-            parts = row.split("=")
-            yield {"updated": row[1], "pid": "S" + row[-1]}
+            parts = row.strip().split("=")
+            yield {"updated": parts[1], "pid": "S" + parts[-1]}

--- a/dsm/extdeps/isis_migration/migration_manager.py
+++ b/dsm/extdeps/isis_migration/migration_manager.py
@@ -115,6 +115,25 @@ class MigrationManager:
     def db_connect(self):
         db.mk_connection(self._db_url)
 
+    def create_mininum_record_in_isis_doc(self, pid, isis_updated_date):
+        """
+        Create a record in isis_doc only with pid, isis_updated_date and
+        status == "pending_migration"
+        """
+        isis_document = (
+            db.fetch_isis_document(pid) or
+            db.create_isis_document()
+        )
+        tracker = None
+        if isis_document.isis_updated_date != isis_updated_date:
+            tracker = Tracker("create_mininum_record_in_isis_doc")
+            tracker.info("created minimum record")
+            isis_document._id = pid
+            isis_document.isis_updated_date = isis_updated_date
+            isis_document.status = "pending_migration"
+            db.save_data(isis_document)
+        return isis_document, tracker
+
     def register_isis_document(self, _id, records):
         """
         Register migrated document data

--- a/dsm/extdeps/isis_migration/migration_manager.py
+++ b/dsm/extdeps/isis_migration/migration_manager.py
@@ -1342,7 +1342,7 @@ def get_document_pids_to_migrate(from_date=None, to_date=None):
         f'''{output_file_path};'''
         f'''echo finished> {finished_file_path}'''
     )
-
+    os.system(cmd)
     while "finished" not in read_file(finished_file_path):
         pass
 

--- a/dsm/extdeps/isis_migration/migration_manager.py
+++ b/dsm/extdeps/isis_migration/migration_manager.py
@@ -17,6 +17,7 @@ from dsm.utils.files import (
     create_temp_file,
     read_from_zipfile,
     read_file,
+    date_now_as_folder_name,
 )
 from dsm.configuration import (
     check_migration_sources,
@@ -28,6 +29,8 @@ from dsm.configuration import (
     get_files_storage_folder_for_published_xmls,
     get_files_storage_folder_for_migration,
     get_htdocs_path,
+    get_cisis_path,
+    get_bases_artigo_path,
 )
 from dsm.core.issue import get_bundle_id
 from dsm.core.document import (
@@ -1300,3 +1303,45 @@ class MigratedDocument:
             remote=remote, local=os.path.basename(zip_file_path))
         self.tracker.info(f"total of zipped files: {len(self.files_to_zip)}")
         return zip_file_path
+
+
+def get_document_pids_to_migrate(from_date=None, to_date=None):
+    """
+    Consulta a base de dados ISIS artigo e retorna os pids atualizados
+    em um intervalo de datas (data de processamento do converter)
+
+    """
+    BASES_ARTIGO_PATH = get_bases_artigo_path()
+    name = date_now_as_folder_name()
+    finished_file_path = create_temp_file(f"{name}_finished.out")
+    output_file_path = create_temp_file(f"{name}_output.csv")
+    from_date = from_date or '0'*8
+    to_date = to_date or '9'*8
+    cmd = (
+        f'''{get_cisis_path()}/ifkeys {BASES_ARTIGO_PATH} '''
+        f'''from=OAITS={from_date} to=OAITS={to_date} > '''
+        f'''{output_file_path};'''
+        f'''echo finished> {finished_file_path}'''
+    )
+
+    while "finished" not in read_file(finished_file_path):
+        pass
+
+    with open(output_file_path, "r") as fp:
+        """
+        output_file content
+
+         1|OAITS=20210917=2352-22912021005005225
+         1|OAITS=20210917=2352-22912021005005226
+         1|OAITS=20210917=2352-22912021005005227
+         1|OAITS=20210917=2352-22912021005005228
+         1|OAITS=20210917=2675-54752021000300400
+         1|OAITS=20210917=2675-54752021000300401
+         1|OAITS=20210917=2675-54752021000300402
+         1|OAITS=20210917=2675-54752021000300700
+
+        """
+        for row in fp:
+            # 1|OAITS=20210917=2675-54752021000300700
+            parts = row.split("=")
+            yield {"updated": row[1], "pid": "S" + row[-1]}

--- a/dsm/migration.py
+++ b/dsm/migration.py
@@ -9,6 +9,7 @@ from dsm.extdeps.isis_migration import (
     id2json,
     migration_manager,
     friendly_isis,
+    get_document_pids_to_migrate,
 )
 from dsm import configuration
 from dsm.core.issue import get_bundle_id
@@ -467,6 +468,13 @@ def migrate_acron(acron, id_folder_path=None):
         yield res
 
 
+def identify_documents_to_migrate():
+    for doc in get_document_pids_to_migrate():
+        yield _migration_manager.create_mininum_record_in_isis_doc(
+            doc["pid"], doc["updated"]
+        )
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="ISIS database migration tool")
@@ -588,33 +596,6 @@ def main():
         help="Updated from"
     )
     register_documents_parser.add_argument(
-        "--updated_to",
-        help="Updated to"
-    )
-
-    register_external_p_records_parser = subparsers.add_parser(
-        "register_external_p_records",
-        help=(
-            "Update the p records using external records"
-        ),
-    )
-    register_external_p_records_parser.add_argument(
-        "--pub_year",
-        help="Publication year",
-    )
-    register_external_p_records_parser.add_argument(
-        "--acron",
-        help="Journal acronym",
-    )
-    register_external_p_records_parser.add_argument(
-        "--issue_folder",
-        help="Issue folder (e.g.: v20n1)",
-    )
-    register_external_p_records_parser.add_argument(
-        "--updated_from",
-        help="Updated from"
-    )
-    register_external_p_records_parser.add_argument(
         "--updated_to",
         help="Updated to"
     )

--- a/dsm/migration.py
+++ b/dsm/migration.py
@@ -9,7 +9,6 @@ from dsm.extdeps.isis_migration import (
     id2json,
     migration_manager,
     friendly_isis,
-    get_document_pids_to_migrate,
 )
 from dsm import configuration
 from dsm.core.issue import get_bundle_id
@@ -469,7 +468,7 @@ def migrate_acron(acron, id_folder_path=None):
 
 
 def identify_documents_to_migrate(from_date=None, to_date=None):
-    for doc in get_document_pids_to_migrate(from_date, to_date):
+    for doc in migration_manager.get_document_pids_to_migrate(from_date, to_date):
         yield _migration_manager.create_mininum_record_in_isis_doc(
             doc["pid"], doc["updated"]
         )

--- a/dsm/migration.py
+++ b/dsm/migration.py
@@ -468,8 +468,8 @@ def migrate_acron(acron, id_folder_path=None):
         yield res
 
 
-def identify_documents_to_migrate():
-    for doc in get_document_pids_to_migrate():
+def identify_documents_to_migrate(from_date=None, to_date=None):
+    for doc in get_document_pids_to_migrate(from_date, to_date):
         yield _migration_manager.create_mininum_record_in_isis_doc(
             doc["pid"], doc["updated"]
         )
@@ -569,6 +569,19 @@ def main():
         help="Path of ID file that will be imported"
     )
 
+    identify_documents_to_migrate_parser = subparsers.add_parser(
+        "identify_documents_to_migrate",
+        help="Register the pid and isis_updated_date in isis_doc",
+    )
+    identify_documents_to_migrate_parser.add_argument(
+        "--from_date",
+        help="from date",
+    )
+    identify_documents_to_migrate_parser.add_argument(
+        "--to_date",
+        help="to date",
+    )
+
     register_documents_parser = subparsers.add_parser(
         "register_documents",
         help=(
@@ -624,6 +637,8 @@ def main():
         create_id_file(args.db_file_path, args.id_file_path)
     elif args.command == "migrate_acron":
         result = migrate_acron(args.acron, args.id_folder_path)
+    elif args.command == "identify_documents_to_migrate":
+        result = identify_documents_to_migrate(args.from_date, args.to_date)
     else:
         parser.print_help()
 

--- a/dsm/migration.py
+++ b/dsm/migration.py
@@ -14,6 +14,7 @@ from dsm import configuration
 from dsm.core.issue import get_bundle_id
 from dsm.core.document import DocsManager
 from dsm.utils.files import create_temp_file, size, read_file
+
 from dsm import exceptions
 
 

--- a/dsm/migration.py
+++ b/dsm/migration.py
@@ -8,12 +8,10 @@ from datetime import datetime
 from dsm.extdeps.isis_migration import (
     id2json,
     migration_manager,
-    friendly_isis,
 )
 from dsm import configuration
-from dsm.core.issue import get_bundle_id
 from dsm.core.document import DocsManager
-from dsm.utils.files import create_temp_file, size, read_file
+from dsm.utils.files import create_temp_file, size, read_file, write_file
 
 from dsm import exceptions
 


### PR DESCRIPTION
#### O que esse PR faz?
- Cria a funcionalidade para carregar somente os pids e a data de atualização da base isis em `isis_doc` de forma a saber quais documentos deverão ser migrados. Esta funcionalidade pode ser reexecutada por completo ou fornecido um intervalo de  tempo.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Estabelecer as variáveis de ambiente

```console

export CISIS_PATH=/var/www/scielo/proc/cisis
export BASES_WORK_PATH=tests/fixtures/bases-work
export BASES_PDF_PATH=tests/fixtures/bases/pdf
export BASES_XML_PATH=tests/fixtures/bases/xml
export BASES_TRANSLATION_PATH=tests/fixtures/bases/translation
export HTDOCS_IMG_REVISTAS_PATH=tests/fixtures/htdocs/img/revistas

export DATABASE_CONNECT_URL="mongodb://127.0.0.1:27017/meu_opac"

export MINIO_ACCESS_KEY=minio
export MINIO_HOST=192.168.1.19:9000
export MINIO_SCIELO_COLLECTION=bra
export MINIO_SECRET_KEY=minio123
export MINIO_SPF_DIR=spf
export MINIO_TIMEOUT=1000000
export MINIO_SECURE=DJLAJFADJFA

```
Nota que o valor de `MINIO_HOST` não pode ser localhost, pois se o for não será visível no site.


Teste para carregar todos os pids que devem ser migrados da base isis artigo para o mongodb.

```console
python dsm/migration.py identify_documents_to_migrate
```
Como resultado serão criados registros na coleção `isis_doc` do mongodb com apenas pid, isis_updated_date e status == `pendind_migration`.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#43

### Referências
n/a
