### PR TITLE
Adiciona capacidade de ter múltiplos pacotes zip por pid v3

### DIFF
--- a/dsm/core/document.py
+++ b/dsm/core/document.py
@@ -63,9 +63,9 @@ class DocsManager:
     def get_articles_files(self, **kwargs):
         return db.fetch_articles_files(**kwargs)
 
-    def get_zip_document_package(self, v3):
+    def get_zip_document_packages(self, v3):
         """
-        Get uri of zip document package or
+        Get uri of zip document packages or
         Build the zip document package and return uri
 
         Parameters
@@ -75,8 +75,8 @@ class DocsManager:
 
         Returns
         -------
-        str
-            URI of the zip file
+        list
+            URIs of the zip files
 
         Raises
         ------
@@ -84,19 +84,13 @@ class DocsManager:
             dsm.exceptions.FetchDocumentError
             dsm.exceptions.DBConnectError
         """
-        document_package = db.fetch_document_package(v3)
+        doc_package_list = db.fetch_document_packages(v3)
 
-        if not document_package:
+        if not doc_package_list:
             document_package = self.update_document_package(v3)
+            return [_convert_to_doc_pkg_uri_detail(document_package)]
 
-        if document_package:
-            if document_package.file:
-                return {
-                    "uri": document_package.file.uri,
-                    "name": document_package.file.name,
-                    "created": document_package.created,
-                    "updated": document_package.updated
-                }
+        return [_convert_to_doc_pkg_uri_detail(dp) for dp in doc_package_list]
 
     def update_document_package(self, v3):
         doc = db.fetch_document(v3)
@@ -572,3 +566,11 @@ def _get_order(xml_sps, document_order):
 #             return True
 #     return False
 
+def _convert_to_doc_pkg_uri_detail(document_package):
+    if document_package.file:
+        return {
+            "uri": document_package.file.uri,
+            "name": document_package.file.name,
+            "created": document_package.created,
+            "updated": document_package.updated,
+        }

--- a/dsm/extdeps/db.py
+++ b/dsm/extdeps/db.py
@@ -276,10 +276,9 @@ def register_document_package(v3, data):
     data['renditions'] = renditions
     data['file'] = file
     """
-    article_files = fetch_document_package(v3)
-    if not article_files:
-        article_files = v2_models.ArticleFiles()
-        article_files._id = v3
+    article_files = v2_models.ArticleFiles()
+    article_files.aid = v3
+    article_files.scielo_pids = {'v3': v3}
 
     _set_document_package_file_paths(article_files, data)
     save_data(article_files)

--- a/dsm/extdeps/db.py
+++ b/dsm/extdeps/db.py
@@ -251,9 +251,7 @@ def register_received_package(_id, uri, name, annotation=None):
 
 
 def fetch_document_packages(v3):
-    article_files_list = v2_models.ArticleFiles.objects(aid=v3)
-    if len(article_files_list) > 0:
-        return article_files_list.order_by('-updated')
+    return v2_models.ArticleFiles.objects(aid=v3).order_by('-updated')
 
 
 def remove_document_package(v3):

--- a/dsm/extdeps/db.py
+++ b/dsm/extdeps/db.py
@@ -250,10 +250,10 @@ def register_received_package(_id, uri, name, annotation=None):
     return save_data(received)
 
 
-def fetch_document_package(v3):
-    article_files = v2_models.ArticleFiles.objects(_id=v3)
-    if len(article_files) > 0:
-        return article_files[0]
+def fetch_document_packages(v3):
+    article_files_list = v2_models.ArticleFiles.objects(aid=v3)
+    if len(article_files_list) > 0:
+        return article_files_list.order_by('-updated')
 
 
 def remove_document_package(v3):

--- a/dsm/ingress.py
+++ b/dsm/ingress.py
@@ -45,11 +45,11 @@ def get_package_uri_by_pid(scielo_pid_v3):
         dsm.exceptions.FetchDocumentError
         dsm.exceptions.DBConnectError
     """
-    results = {'doc_pkg': [], 'errors': []}
+    results = {'doc_pkgs': [], 'errors': []}
     try:
-        doc_pkg = _docs_manager.get_zip_document_package(scielo_pid_v3)
-        if doc_pkg:
-            results['doc_pkg'].append(doc_pkg)
+        doc_pkgs = _docs_manager.get_zip_document_packages(scielo_pid_v3)
+        if doc_pkgs:
+            results['doc_pkgs'].extend(doc_pkgs)
     except Exception as e:
         results['errors'].append(str(e))
 


### PR DESCRIPTION
#### O que esse PR faz?
Altera os módulos db.py, document.py e ingress.py para suportarem a capacidade de um PIDv3 ter múltiplos registros na coleção article_files.

#### Onde a revisão poderia começar?
Por commits.

#### Como este poderia ser testado manualmente?
1. É preciso alterar o opac_schema utilizado de modo que o modelo v2.ArticleFiles tenha os campos `aid` e `scielo_pids` (como existe no modelo v1.Article). E não tenha o campo `_id`.
2. É preciso gravar múltiplos registros na coleção article_files, todos contendo o mesmo `aid` (que passa a ser chave pesquisável e não única).
3. Ao pesquisar por um PID v3, todos os dicionários associados a ele devem ser retornados.

#### Algum cenário de contexto que queira dar?
É preciso que o modelo `v2.ArticleFiles` do opac_schema tenha os campos `aid` e `scielo_pids`. E que o campo _id seja removido, permitindo sua geração de forma alealtória pela MongoEngine.

Sendo este PR aprovado, um outro PR no opac_schema deve ser enviado com as alterações no modelo `v2.ArticleFiles`.

### Screenshots
Tela da aplicação SPF já usando um opac_schema e dsm atualizados com este PR. Observe que o primeiro registro é o mais recente.
![image](https://user-images.githubusercontent.com/2096125/138009067-ba5e1158-18ac-4a0d-934f-49dee88202c2.png)


#### Quais são tickets relevantes?
N/A

### Referências
Parte de #54