### PR TITLE
Adiciona capacidade de alterar versão de documento com base em pacote

### DIFF
--- a/dsm/core/document.py
+++ b/dsm/core/document.py
@@ -62,6 +62,8 @@ class DocsManager:
         zip_file_uri = article_files.file['uri']
         issn = files.extract_issn_from_zip_uri(zip_file_uri)
 
+        prefix_name = files.get_prefix_by_xml_filename(article_files.xml.name)
+
         # obtém pacote
         zip_file_content = reqs.requests_get(zip_file_uri)
         zip_file_path = files.create_temp_file(
@@ -75,7 +77,8 @@ class DocsManager:
             self._files_storage,
             zip_file_path,
             issn,
-            pid_v3
+            pid_v3,
+            prefix_name
         )
 
         article = db.fetch_document(pid_v3)

--- a/dsm/core/document.py
+++ b/dsm/core/document.py
@@ -2,14 +2,15 @@
 # Module does the same as ArticleFactory from opac-airflow
 
 import logging
-
+from posixpath import basename
 from opac_schema.v1 import models
-
-from dsm.utils import packages
-
+from dsm.utils import (
+    packages,
+    reqs,
+    files
+)
 from dsm.core.sps_package import SPS_Package
 from dsm.core import document_files as docfiles
-
 from dsm.extdeps.doc_ids_manager import add_pids_to_xml
 from dsm.extdeps import db
 from dsm import exceptions

--- a/dsm/core/document.py
+++ b/dsm/core/document.py
@@ -55,14 +55,8 @@ class DocsManager:
 
         return db.save_data(document)
 
-    def remove_document_package(self, document_package_id):
-        return db.remove_document_package(document_package_id)
 
-    def get_article_files(self, id):
-        return db.fetch_article_files(id)
 
-    def get_articles_files(self, **kwargs):
-        return db.fetch_articles_files(**kwargs)
 
     def get_zip_document_packages(self, v3):
         """

--- a/dsm/core/document.py
+++ b/dsm/core/document.py
@@ -101,16 +101,21 @@ class DocsManager:
             mode='wb'
         )
 
+        article = db.fetch_document(pid_v3)
+
+        # obtém idiomas dos PDFs do artigo
+        pdf_langs = _extract_pdf_langs(article)
+
         # envia dados descompactados do pacote Zip para o file storage
         uris_and_names = docfiles.send_doc_package_to_site(
             self._files_storage,
             zip_file_path,
             issn,
             pid_v3,
-            prefix_name
+            prefix_name,
+            pdf_langs,
         )
 
-        article = db.fetch_document(pid_v3)
         xml_sps = docfiles._get_xml_sps(article)
 
         update_document_data(
@@ -635,3 +640,7 @@ def _convert_to_doc_pkg_uri_detail(document_package):
             "created": document_package.created,
             "updated": document_package.updated,
         }
+
+
+def _extract_pdf_langs(article):
+    return [i.get('lang') for i in article.pdfs]

--- a/dsm/core/document.py
+++ b/dsm/core/document.py
@@ -55,6 +55,8 @@ class DocsManager:
 
         return db.save_data(document)
 
+    def get_document_package_by_pid_and_version(self, pid, version):
+        return db.fetch_document_package_by_pid_and_version(pid, version)
 
 
 

--- a/dsm/core/document_files.py
+++ b/dsm/core/document_files.py
@@ -63,6 +63,27 @@ def build_zip_package(files_storage, record):
 
 
 def send_doc_package_to_site(files_storage, zip_file, issn, pid_v3, prefix):
+    """
+    Envia para o file storage os dados descompactados de um zip
+
+    Parameters
+    ----------
+    files_storage : dsm.storage.minio.MinioStorage
+        Objeto files storage
+    zip_file: str
+        Caminho do arquivo zip
+    issn: string
+        ISSN do periódico
+    pid_v3: str
+        Identificador PID v3
+    prefix: str
+        Prefixo associado ao documento
+
+    Returns
+    -------
+    list
+        Uma lista contendo os caminhos dos arquivos associados ao documento
+    """
     # obtém pasta destino visível ao opac
     files_storage_folder_site_content = configuration.get_files_storage_folder_for_document_site_content(
         issn=issn,

--- a/dsm/core/document_files.py
+++ b/dsm/core/document_files.py
@@ -62,7 +62,7 @@ def build_zip_package(files_storage, record):
     return data
 
 
-def send_doc_package_to_site(files_storage, zip_file, issn, pid_v3):
+def send_doc_package_to_site(files_storage, zip_file, issn, pid_v3, prefix):
     # obtém pasta destino visível ao opac
     files_storage_folder_site_content = configuration.get_files_storage_folder_for_document_site_content(
         issn=issn,
@@ -76,7 +76,7 @@ def send_doc_package_to_site(files_storage, zip_file, issn, pid_v3):
         fi_read = files.read_from_zipfile(zip_file, fi)
         fi_path = files.create_temp_file(fi, fi_read, 'wb')
 
-        file_type = files.get_file_type(fi)
+        file_type = files.get_file_type(fi, prefix)
 
         fi_result = files_storage_register(
             files_storage,

--- a/dsm/core/document_files.py
+++ b/dsm/core/document_files.py
@@ -62,6 +62,36 @@ def build_zip_package(files_storage, record):
     return data
 
 
+def send_doc_package_to_site(files_storage, zip_file, issn, pid_v3):
+    # obtém pasta destino visível ao opac
+    files_storage_folder_site_content = configuration.get_files_storage_folder_for_document_site_content(
+        issn=issn,
+        scielo_pid_v3=pid_v3,
+    )
+
+    files_paths = {'xml': '', 'assets': [], 'renditions': []}
+
+    # descompacta zip e envia conteúdo ao files storage
+    for fi in files.files_list_from_zipfile(zip_file):
+        fi_read = files.read_from_zipfile(zip_file, fi)
+        fi_path = files.create_temp_file(fi, fi_read, 'wb')
+
+        file_type = files.get_file_type(fi)
+
+        fi_result = files_storage_register(
+            files_storage,
+            files_storage_folder_site_content,
+            fi_path,
+            os.path.basename(fi_path))
+
+        if file_type == 'xml':
+            files_paths[file_type] = fi_result
+        else:
+            files_paths[file_type].append(fi_result)
+
+    return files_paths
+
+
 def _get_xml_sps(document):
     """
     Download XML file and instantiate a `SPS_Package`

--- a/dsm/core/document_files.py
+++ b/dsm/core/document_files.py
@@ -62,7 +62,7 @@ def build_zip_package(files_storage, record):
     return data
 
 
-def send_doc_package_to_site(files_storage, zip_file, issn, pid_v3, prefix):
+def send_doc_package_to_site(files_storage, zip_file, issn, pid_v3, prefix, pdf_langs):
     """
     Envia para o file storage os dados descompactados de um zip
 
@@ -78,6 +78,8 @@ def send_doc_package_to_site(files_storage, zip_file, issn, pid_v3, prefix):
         Identificador PID v3
     prefix: str
         Prefixo associado ao documento
+    pdf_langs: list
+        Idiomas dos PDFs do documento
 
     Returns
     -------
@@ -97,7 +99,7 @@ def send_doc_package_to_site(files_storage, zip_file, issn, pid_v3, prefix):
         fi_read = files.read_from_zipfile(zip_file, fi)
         fi_path = files.create_temp_file(fi, fi_read, 'wb')
 
-        file_type = files.get_file_type(fi, prefix)
+        file_type = files.get_file_type(fi, prefix, pdf_langs)
 
         fi_result = files_storage_register(
             files_storage,

--- a/dsm/core/document_files.py
+++ b/dsm/core/document_files.py
@@ -99,7 +99,7 @@ def send_doc_package_to_site(files_storage, zip_file, issn, pid_v3, prefix, pdf_
         fi_read = files.read_from_zipfile(zip_file, fi)
         fi_path = files.create_temp_file(fi, fi_read, 'wb')
 
-        file_type = files.get_file_type(fi, prefix, pdf_langs)
+        file_role = files.get_file_role(fi, prefix, pdf_langs)
 
         fi_result = files_storage_register(
             files_storage,
@@ -107,10 +107,10 @@ def send_doc_package_to_site(files_storage, zip_file, issn, pid_v3, prefix, pdf_
             fi_path,
             os.path.basename(fi_path))
 
-        if file_type == 'xml':
-            files_paths[file_type] = fi_result
+        if file_role == 'xml':
+            files_paths[file_role] = fi_result
         else:
-            files_paths[file_type].append(fi_result)
+            files_paths[file_role].append(fi_result)
 
     return files_paths
 

--- a/dsm/extdeps/db.py
+++ b/dsm/extdeps/db.py
@@ -130,10 +130,6 @@ def _fetch_records(model, **kwargs):
         return objs
 
 
-def fetch_article_files(pid, **kwargs):
-    return _fetch_record(pid, v2_models.ArticleFiles, **kwargs)
-
-
 def fetch_articles_files(**kwargs):
     return _fetch_records(v2_models.ArticleFiles, **kwargs)
 
@@ -254,16 +250,6 @@ def fetch_document_packages(v3):
     return v2_models.ArticleFiles.objects(aid=v3).order_by('-updated')
 
 
-def remove_document_package(v3):
-    try:
-        doc_pkg = v2_models.ArticleFiles.objects.get(_id=v3)
-        doc_pkg.delete()
-    except Exception as e:
-        raise exceptions.DBFetchDocumentPackageError(
-            "Unable to delete document package %s, which does not exists: %s" %
-            (v3, e)
-        )
-    return True
 
 
 def register_document_package(v3, data):

--- a/dsm/extdeps/db.py
+++ b/dsm/extdeps/db.py
@@ -131,7 +131,7 @@ def _fetch_records(model, **kwargs):
 
 
 def fetch_articles_files(**kwargs):
-    return _fetch_records(v2_models.ArticleFiles, **kwargs)
+    return v2_models.ArticleFiles.objects(**kwargs)
 
 
 def fetch_journals(**kwargs):
@@ -250,6 +250,11 @@ def fetch_document_packages(v3):
     return v2_models.ArticleFiles.objects(aid=v3).order_by('-updated')
 
 
+def fetch_document_package_by_pid_and_version(pid, version):
+    return v2_models.ArticleFiles.objects.get(
+        aid = pid,
+        version = version
+    )
 
 
 def register_document_package(v3, data):

--- a/dsm/ingress.py
+++ b/dsm/ingress.py
@@ -2,8 +2,8 @@
 API to ingress documents
 """
 import argparse
-from datetime import datetime
 
+from datetime import datetime
 from dsm.core.document import DocsManager
 from dsm.core.issue import IssuesManager
 from dsm.core.journal import JournalsManager
@@ -54,6 +54,26 @@ def get_package_uri_by_pid(scielo_pid_v3):
         results['errors'].append(str(e))
 
     return results
+
+
+def change_document_to_package_version(scielo_pid_v3, package_version):
+    """
+    Altera os dados de um documento para uma versão específica de pacote
+
+    Parameters
+    ----------
+    scielo_pid_v3 : str
+        document's identifier version 3
+    package_version: int
+        documente package (article_files) version
+    """
+    # obtém article_files do pacote relacionado à versão `package_version`
+    article_files = _docs_manager.get_document_package_by_pid_and_version(pid=scielo_pid_v3, version=package_version)
+
+    # altera dados de article para conteúdo de article files
+    article = _docs_manager.change_document_package(scielo_pid_v3, article_files)
+
+    return article
 
 
 def upload_package(source, receipt_id=None, pid_v2_items={}, old_filenames={},
@@ -118,17 +138,16 @@ def upload_package(source, receipt_id=None, pid_v2_items={}, old_filenames={},
     return results
 
 
-def list_documents(**kwargs):
-    # TODO
-    return []
-
-
 def _download_package(v3):
     print(get_package_uri_by_pid(v3))
 
 
 def _upload_package(path):
     print(upload_package(path))
+
+
+def _change_document_version(v3, version):
+    print(change_document_to_package_version(v3, version))
 
 
 def main():
@@ -159,12 +178,29 @@ def main():
         help="zip file path"
     )
 
+    change_document_version_parser = subparsers.add_parser(
+        "change_document_version",
+        help=(
+            "Change document version"
+        )
+    )
+    change_document_version_parser.add_argument(
+        "v3",
+        help="PID v3"
+    )
+    change_document_version_parser.add_argument(
+        "version",
+        help="Document package version (integer)"
+    )
+
     args = parser.parse_args()
 
     if args.command == "download_package":
         _download_package(args.v3)
     elif args.command == "upload_package":
         _upload_package(args.source_path)
+    elif args.command == "change_document_version":
+        _change_document_version(args.v3, args.version)
     else:
         parser.print_help()
 

--- a/dsm/utils/files.py
+++ b/dsm/utils/files.py
@@ -141,7 +141,7 @@ def get_prefix_by_xml_filename(xml_filename):
     return file
 
 
-def get_file_type(file_path, prefix):
+def get_file_type(file_path, prefix, pdf_langs):
     """
     Obtém o tipo de um arquivo (xml, renditions ou assets)
 
@@ -151,6 +151,8 @@ def get_file_type(file_path, prefix):
         Nome de um arquivo
     prefix: str
         Prefixo associado ao arquivo
+    pdf_langs: list
+        Idiomas dos PDFs do documento
 
     Returns
     -------
@@ -162,8 +164,12 @@ def get_file_type(file_path, prefix):
     if ext == '.xml':
         return 'xml'
     elif ext == '.pdf':
-        if prefix in file:
+        if file == prefix:
             return 'renditions'
+
+        for lang in pdf_langs:
+            if file == f'{prefix}-{lang}':
+                return 'renditions'
     else:
         return 'assets'
 

--- a/dsm/utils/files.py
+++ b/dsm/utils/files.py
@@ -170,8 +170,7 @@ def get_file_role(file_path, prefix, pdf_langs):
         for lang in pdf_langs:
             if file == f'{prefix}-{lang}':
                 return 'renditions'
-    else:
-        return 'assets'
+    return 'assets'
 
 
 def extract_issn_from_zip_uri(zip_uri):

--- a/dsm/utils/files.py
+++ b/dsm/utils/files.py
@@ -111,10 +111,10 @@ def date_now_as_folder_name():
     return datetime.utcnow().isoformat().replace(":", "")
 
 
-def create_temp_file(filename, content=None):
+def create_temp_file(filename, content=None, mode='w'):
     file_path = tempfile.mkdtemp()
     file_path = os.path.join(file_path, filename)
-    write_file(file_path, content or '')
+    write_file(file_path, content or '', mode)
     return file_path
 
 

--- a/dsm/utils/files.py
+++ b/dsm/utils/files.py
@@ -123,6 +123,24 @@ def size(file_path):
     return os.path.getsize(file_path)
 
 
+def get_prefix_by_xml_filename(xml_filename):
+    """
+    Obtém o prefixo associado a um arquivo xml
+
+    Parameters
+    ----------
+    xml_filename : str
+        Nome de arquivo xml
+
+    Returns
+    -------
+    str
+        Prefixo associado ao arquivo xml
+    """
+    file, ext = os.path.splitext(xml_filename)
+    return file
+
+
 def get_file_type(file_path, prefix):
     """
     Obtém o tipo de um arquivo (xml, renditions ou assets)

--- a/dsm/utils/files.py
+++ b/dsm/utils/files.py
@@ -141,9 +141,9 @@ def get_prefix_by_xml_filename(xml_filename):
     return file
 
 
-def get_file_type(file_path, prefix, pdf_langs):
+def get_file_role(file_path, prefix, pdf_langs):
     """
-    Obtém o tipo de um arquivo (xml, renditions ou assets)
+    Obtém o papel/função de um arquivo (xml, renditions ou assets) no contexto de um documento
 
     Parameters
     ----------
@@ -157,7 +157,7 @@ def get_file_type(file_path, prefix, pdf_langs):
     Returns
     -------
     str
-        Tipo de arquivo (xml, rendition ou assets)
+        Papel/função de arquivo (xml, rendition ou assets) no contexto de um documento
     """
     file, ext = os.path.splitext(file_path)
 

--- a/dsm/utils/files.py
+++ b/dsm/utils/files.py
@@ -123,12 +123,14 @@ def size(file_path):
     return os.path.getsize(file_path)
 
 
-def get_file_type(file_path):
-    file_ext = os.path.splitext(file_path)[-1]
-    if file_ext == '.xml':
+def get_file_type(file_path, prefix):
+    file, ext = os.path.splitext(file_path)
+
+    if ext == '.xml':
         return 'xml'
-    elif file_ext == '.pdf':
-        return 'renditions'
+    elif ext == '.pdf':
+        if prefix in file:
+            return 'renditions'
     else:
         return 'assets'
 

--- a/dsm/utils/files.py
+++ b/dsm/utils/files.py
@@ -124,6 +124,21 @@ def size(file_path):
 
 
 def get_file_type(file_path, prefix):
+    """
+    Obtém o tipo de um arquivo (xml, renditions ou assets)
+
+    Parameters
+    ----------
+    file_path : str
+        Nome de um arquivo
+    prefix: str
+        Prefixo associado ao arquivo
+
+    Returns
+    -------
+    str
+        Tipo de arquivo (xml, rendition ou assets)
+    """
     file, ext = os.path.splitext(file_path)
 
     if ext == '.xml':
@@ -136,6 +151,19 @@ def get_file_type(file_path, prefix):
 
 
 def extract_issn_from_zip_uri(zip_uri):
+    """
+    Extrai código ISSN a partir do endereço de um arquivo zip
+
+    Parameters
+    ----------
+    zip_uri : str
+        Endereço de um arquivo zip
+
+    Returns
+    -------
+    str
+        ISSN
+    """
     match = re.search(r'.*/ingress/packages/(\d{4}-\d{4})/.*.zip', zip_uri)
     if match:
         return match.group(1)

--- a/dsm/utils/files.py
+++ b/dsm/utils/files.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import logging
 import tempfile
+import re
 from datetime import datetime
 from zipfile import ZipFile
 
@@ -121,3 +122,18 @@ def create_temp_file(filename, content=None, mode='w'):
 def size(file_path):
     return os.path.getsize(file_path)
 
+
+def get_file_type(file_path):
+    file_ext = os.path.splitext(file_path)[-1]
+    if file_ext == '.xml':
+        return 'xml'
+    elif file_ext == '.pdf':
+        return 'renditions'
+    else:
+        return 'assets'
+
+
+def extract_issn_from_zip_uri(zip_uri):
+    match = re.search(r'.*/ingress/packages/(\d{4}-\d{4})/.*.zip', zip_uri)
+    if match:
+        return match.group(1)


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona um arcabouço que permite alterar os dados de um documento no site com base em uma versão de pacote.

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
É preciso enviar pelo menos dois pacotes relacionados a um mesmo artigo. Depois, pode-se executar a nova funcionalidade para retornar o documento para uma versão anterior. Seguem as instruções:

```
python dsm/ingress.py upload_package ZIP_DA_VERSAO_1
python dsm/ingress.py upload_package ZIP_DA_VERSAO_2
python dsm/ingress.py change_document_version PID NUMERO_DA_VERSAO
```

Sugestão:

```
# busque um pacote que ainda não existe no article_files
# isso gerará um pacote em que version é 1
python dsm/ingress.py download_package KmHpPYrB3r77Nm7yzV68hZg

# faça alterações no zip coletado
# envie o zip coletado - o valor de version será 2
# e veja os dados alterados no site
python dsm/ingress.py upload_package ZIP_ALTERADO

# volte o documento no site para a versão 1 (e verifique no site que o conteúdo voltou a ser da version 1)
python dsm/ingress.py change_document_version PID 1
```

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A